### PR TITLE
 Don't shade Party And Friends 

### DIFF
--- a/partyandfriendsaddon/pom.xml
+++ b/partyandfriendsaddon/pom.xml
@@ -71,7 +71,8 @@
         <dependency>
             <groupId>de.simonsator</groupId>
             <artifactId>BungeecordPartyAndFriends</artifactId>
-            <version>1.0.85</version>
+            <version>1.0.86</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.md-5</groupId>
@@ -88,11 +89,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.jaimemartz.playerbalancer</groupId>
-            <artifactId>PlayerBalancer</artifactId>
-            <version>2.3.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/release/PlayerBalancer-2.3.0.jar</systemPath>
+            <groupId>com.jaimemartz</groupId>
+            <artifactId>playerbalancer</artifactId>
+            <version>2.3.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/partyandfriendsaddon/src/main/java/com/bghddevelopment/partyandfriendsaddon/PBServerConnector.java
+++ b/partyandfriendsaddon/src/main/java/com/bghddevelopment/partyandfriendsaddon/PBServerConnector.java
@@ -4,6 +4,7 @@ import de.simonsator.partyandfriends.api.PAFExtension;
 import de.simonsator.partyandfriends.api.friends.ServerConnector;
 import de.simonsator.partyandfriends.api.pafplayers.PAFPlayerClass;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
@@ -15,7 +16,7 @@ public class PBServerConnector extends PAFExtension implements ServerConnector {
 
     public void onEnable() {
         PAFPlayerClass.setServerConnector(this);
-        ProxyServer.getInstance().getConsole().sendMessage("Enabled PBServerConnector connection for PlayerBalancer!");
+        ProxyServer.getInstance().getConsole().sendMessage(TextComponent.fromLegacyText("Enabled PBServerConnector connection for PlayerBalancer!"));
     }
 
     public void connect(final ProxiedPlayer pPlayer, final ServerInfo pServerInfo) {

--- a/partyandfriendsaddon/src/main/java/com/bghddevelopment/partyandfriendsaddon/PBServerConnector.java
+++ b/partyandfriendsaddon/src/main/java/com/bghddevelopment/partyandfriendsaddon/PBServerConnector.java
@@ -17,6 +17,7 @@ public class PBServerConnector extends PAFExtension implements ServerConnector {
     public void onEnable() {
         PAFPlayerClass.setServerConnector(this);
         ProxyServer.getInstance().getConsole().sendMessage(TextComponent.fromLegacyText("Enabled PBServerConnector connection for PlayerBalancer!"));
+        registerAsExtension();
     }
 
     public void connect(final ProxiedPlayer pPlayer, final ServerInfo pServerInfo) {


### PR DESCRIPTION
-  This prevents party and friends to be shaded into the produced jar, which may cause that bungeecord loads the included version of party and friends instead of the correct one from the plugins folder
-  Also playerbalancer is now a normal maven dependency
-  Fixed extension not being registered as an extension 
-  Stop using legacy chat api in the paf extension